### PR TITLE
Updates README to show full json example for colorschemes

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,19 +44,23 @@ The Gitstatus segment uses a couple of custom highlight groups. You'll need to d
 for example in `.config/powerline/colorschemes/default.json`:
 
 ```json
-"gitstatus":                 { "fg": "gray8",           "bg": "gray2", "attrs": [] },
-"gitstatus_branch":          { "fg": "gray8",           "bg": "gray2", "attrs": [] },
-"gitstatus_branch_clean":    { "fg": "green",           "bg": "gray2", "attrs": [] },
-"gitstatus_branch_dirty":    { "fg": "gray8",           "bg": "gray2", "attrs": [] },
-"gitstatus_branch_detached": { "fg": "mediumpurple",    "bg": "gray2", "attrs": [] },
-"gitstatus_behind":          { "fg": "gray10",          "bg": "gray2", "attrs": [] },
-"gitstatus_ahead":           { "fg": "gray10",          "bg": "gray2", "attrs": [] },
-"gitstatus_staged":          { "fg": "green",           "bg": "gray2", "attrs": [] },
-"gitstatus_unmerged":        { "fg": "brightred",       "bg": "gray2", "attrs": [] },
-"gitstatus_changed":         { "fg": "mediumorange",    "bg": "gray2", "attrs": [] },
-"gitstatus_untracked":       { "fg": "brightestorange", "bg": "gray2", "attrs": [] },
-"gitstatus_stashed":         { "fg": "darkblue",        "bg": "gray2", "attrs": [] },
-"gitstatus:divider":         { "fg": "gray8",           "bg": "gray2", "attrs": [] }
+{
+  "groups": {
+    "gitstatus":                 { "fg": "gray8",           "bg": "gray2", "attrs": [] },
+    "gitstatus_branch":          { "fg": "gray8",           "bg": "gray2", "attrs": [] },
+    "gitstatus_branch_clean":    { "fg": "green",           "bg": "gray2", "attrs": [] },
+    "gitstatus_branch_dirty":    { "fg": "gray8",           "bg": "gray2", "attrs": [] },
+    "gitstatus_branch_detached": { "fg": "mediumpurple",    "bg": "gray2", "attrs": [] },
+    "gitstatus_behind":          { "fg": "gray10",          "bg": "gray2", "attrs": [] },
+    "gitstatus_ahead":           { "fg": "gray10",          "bg": "gray2", "attrs": [] },
+    "gitstatus_staged":          { "fg": "green",           "bg": "gray2", "attrs": [] },
+    "gitstatus_unmerged":        { "fg": "brightred",       "bg": "gray2", "attrs": [] },
+    "gitstatus_changed":         { "fg": "mediumorange",    "bg": "gray2", "attrs": [] },
+    "gitstatus_untracked":       { "fg": "brightestorange", "bg": "gray2", "attrs": [] },
+    "gitstatus_stashed":         { "fg": "darkblue",        "bg": "gray2", "attrs": [] },
+    "gitstatus:divider":         { "fg": "gray8",           "bg": "gray2", "attrs": [] }
+  }
+}
 ```
 
 Then you can activate the Gitstatus segment by adding it to your segment configuration,


### PR DESCRIPTION
I just added powerline-gitstatus to my shell prompt and it's fantastic. Thanks for making this!

I'm new to Powerline, and it wasn't initially apparent that I needed to configure the highlight groups under a json key named `"groups"`. I thought showing an example of the full json file might help.
