### PR TITLE
Support describe modes from git-prompt.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ You can enable this by passing `true` to the `show_tag` argument, for example in
 }
 ```
 
-You can also specify any describe style that `git-prompt.sh` supports (via its `GIT_PS1_DESCRIBE_STYLE`) by passing `"contains"`, `"branch"`, `"describe"` or `"exact"` (which is `git-prompt.sh`'s `"default"`).
+You can also specify any describe style that `git-prompt.sh` supports (via its `GIT_PS1_DESCRIBE_STYLE`) by passing `"contains"`, `"branch"`, `"tag"`, `"describe"` or `"exact"` (which is `git-prompt.sh`'s `"default"`).
 Git is executed an additional time to find this tag, so it is disabled by default.
 
 License

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ You can enable this by passing `true` to the `show_tag` argument, for example in
 }
 ```
 
+You can also specify any describe style that `git-prompt.sh` supports (via its `GIT_PS1_DESCRIBE_STYLE`) by passing `"contains"`, `"branch"`, `"describe"` or `"exact"` (which is `git-prompt.sh`'s `"default"`).
 Git is executed an additional time to find this tag, so it is disabled by default.
 
 License

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ if that number is greater than zero.
 
 Glossary
 --------
+- `⏳`: in-progress information (if enabled) 
 - ``: branch name or commit hash
 - `★`: most recent tag (if enabled)
 - `↓`: n commits behind
@@ -53,6 +54,7 @@ for example in `.config/powerline/colorschemes/default.json`:
     "gitstatus_branch_dirty":    { "fg": "gray8",           "bg": "gray2", "attrs": [] },
     "gitstatus_branch_detached": { "fg": "mediumpurple",    "bg": "gray2", "attrs": [] },
     "gitstatus_tag":             { "fg": "darkcyan",        "bg": "gray2", "attrs": [] },
+    "gitstatus_inprogress":      { "fg": "red",             "bg": "gray2", "attrs": [] },
     "gitstatus_behind":          { "fg": "gray10",          "bg": "gray2", "attrs": [] },
     "gitstatus_ahead":           { "fg": "gray10",          "bg": "gray2", "attrs": [] },
     "gitstatus_staged":          { "fg": "green",           "bg": "gray2", "attrs": [] },
@@ -101,6 +103,9 @@ You can enable this by passing `true` to the `show_tag` argument, for example in
 
 You can also specify any describe style that `git-prompt.sh` supports (via its `GIT_PS1_DESCRIBE_STYLE`) by passing `"contains"`, `"branch"`, `"tag"`, `"describe"` or `"exact"` (which is `git-prompt.sh`'s `"default"`).
 Git is executed an additional time to find this tag, so it is disabled by default.
+
+Optionally in-progress information can be show (BISECTING, MERGING etc.).
+You can enable this by passing `true` to the `show_inprogress` argument (see above).
 
 License
 -------

--- a/powerline_gitstatus/segments.py
+++ b/powerline_gitstatus/segments.py
@@ -138,15 +138,23 @@ class GitStatusSegment(Segment):
 
         stashed = len(self.execute(pl, base + ['stash', 'list', '--no-decorate'])[0])
 
-        if show_tag:
+        if not show_tag:
+            tag, err = [''], False
+        elif show_tag == 'contains':
+            tag, err = self.execute(pl, base + ['describe', '--contains'])
+        elif show_tag == 'branch':
+            tag, err = self.execute(pl, base + ['describe', '--contains', '--all'])
+        elif show_tag == 'describe':
+            tag, err = self.execute(pl, base + ['describe'])
+        elif show_tag == 'exact': # git-prompt.sh default
+            tag, err = self.execute(pl, base + ['describe', '--tags', '--exact-match'])
+        else: # old non-False
             tag, err = self.execute(pl, base + ['describe', '--tags', '--abbrev=0'])
 
-            if err and ('error' in err[0] or 'fatal' in err[0]):
-                tag = ''
-            else:
-                tag = tag[0]
-        else:
+        if err and ('error' in err[0] or 'fatal' in err[0]):
             tag = ''
+        else:
+            tag = tag[0]
 
         return self.build_segments(branch, detached, tag, behind, ahead, staged, unmerged, changed, untracked, stashed)
 

--- a/powerline_gitstatus/segments.py
+++ b/powerline_gitstatus/segments.py
@@ -144,6 +144,8 @@ class GitStatusSegment(Segment):
             tag, err = self.execute(pl, base + ['describe', '--contains'])
         elif show_tag == 'branch':
             tag, err = self.execute(pl, base + ['describe', '--contains', '--all'])
+        elif show_tag == 'tag':
+            tag, err = self.execute(pl, base + ['describe', '--tags'])
         elif show_tag == 'describe':
             tag, err = self.execute(pl, base + ['describe'])
         elif show_tag == 'exact': # git-prompt.sh default


### PR DESCRIPTION
contrib/completion/git-prompt.sh has various GIT_PS1_DESCRIBE_STYLEs for
describing the current HEAD.

Implement all these modes in addition to the existing one.