### PR TITLE
Allow disabling display of untracked files and stashes to speed up prompt

### DIFF
--- a/powerline_gitstatus/segments.py
+++ b/powerline_gitstatus/segments.py
@@ -108,7 +108,7 @@ class GitStatusSegment(Segment):
 
         return segments
 
-    def __call__(self, pl, segment_info, use_dash_c=True, show_tag=False):
+    def __call__(self, pl, segment_info, use_dash_c=True, show_tag=False, show_untracked=True):
         pl.debug('Running gitstatus %s -C' % ('with' if use_dash_c else 'without'))
 
         cwd = segment_info['getcwd']()
@@ -120,8 +120,12 @@ class GitStatusSegment(Segment):
 
         if not base:
             return
+        status_args = ['status', '--branch', '--porcelain']
+        # finding all untracked files can take a long time
+        if not show_untracked:
+            status_args.append('-uno')
 
-        status, err = self.execute(pl, base + ['status', '--branch', '--porcelain'])
+        status, err = self.execute(pl, base + status_args)
 
         if err and ('error' in err[0] or 'fatal' in err[0]):
             return
@@ -168,6 +172,10 @@ if that number is greater than zero.
 :param bool show_tag:
     Show the most recent tag reachable in the current branch.
     False by default, because it needs to execute git an additional time.
+
+:param bool show_untracked:
+    Show the number of untracked files.
+    True by default but may take a long time to compute in large repositories
 
 Divider highlight group used: ``gitstatus:divider``.
 

--- a/powerline_gitstatus/segments.py
+++ b/powerline_gitstatus/segments.py
@@ -108,7 +108,7 @@ class GitStatusSegment(Segment):
 
         return segments
 
-    def __call__(self, pl, segment_info, use_dash_c=True, show_tag=False, show_untracked=True):
+    def __call__(self, pl, segment_info, use_dash_c=True, show_tag=False, show_stashed=True, show_untracked=True):
         pl.debug('Running gitstatus %s -C' % ('with' if use_dash_c else 'without'))
 
         cwd = segment_info['getcwd']()
@@ -140,7 +140,10 @@ class GitStatusSegment(Segment):
 
         staged, unmerged, changed, untracked = self.parse_status(status)
 
-        stashed = len(self.execute(pl, base + ['stash', 'list', '--no-decorate'])[0])
+        if show_stashed:
+            stashed = len(self.execute(pl, base + ['stash', 'list', '--no-decorate'])[0])
+        else:
+            stashed = 0
 
         if show_tag:
             tag, err = self.execute(pl, base + ['describe', '--tags', '--abbrev=0'])
@@ -176,6 +179,10 @@ if that number is greater than zero.
 :param bool show_untracked:
     Show the number of untracked files.
     True by default but may take a long time to compute in large repositories
+
+:param bool show_stashed:
+    Show the number of stashes.
+    True by default.
 
 Divider highlight group used: ``gitstatus:divider``.
 


### PR DESCRIPTION
Computing the untracked files can take a long time (multiple seconds) and I don't want to wait for my prompt that long. I've added a new config option to disable display of untracked files.