### PR TITLE
Add an option to show the tag only when it directly references the current commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,17 @@ You can enable this by passing `true` to the `show_tag` argument, for example in
 
 Git is executed an additional time to find this tag, so it is disabled by default.
 
+If you only want to show the tag when it directly references the current commit, please set `tag_exact_match` to `true`:
+
+```json
+"gitstatus": {
+    "args": {
+        "show_tag": true,
+        "tag_exact_match": true
+    }
+}
+```
+
 License
 -------
 

--- a/powerline_gitstatus/segments.py
+++ b/powerline_gitstatus/segments.py
@@ -139,7 +139,10 @@ class GitStatusSegment(Segment):
         stashed = len(self.execute(pl, base + ['stash', 'list', '--no-decorate'])[0])
 
         if show_tag:
-            tag, err = self.execute(pl, base + ['describe', '--tags', '--abbrev=0'] + (['--exact-match'] if tag_exact_match else []))
+            if tag_exact_match:
+                tag, err = self.execute(pl, base + ['tag', '--points-at'])
+            else:
+                tag, err = self.execute(pl, base + ['describe', '--tags', '--abbrev=0'])
 
             if err and ('error' in err[0] or 'fatal' in err[0]):
                 tag = ''

--- a/powerline_gitstatus/segments.py
+++ b/powerline_gitstatus/segments.py
@@ -108,7 +108,7 @@ class GitStatusSegment(Segment):
 
         return segments
 
-    def __call__(self, pl, segment_info, use_dash_c=True, show_tag=False):
+    def __call__(self, pl, segment_info, use_dash_c=True, show_tag=False, tag_exact_match=False):
         pl.debug('Running gitstatus %s -C' % ('with' if use_dash_c else 'without'))
 
         cwd = segment_info['getcwd']()
@@ -139,7 +139,7 @@ class GitStatusSegment(Segment):
         stashed = len(self.execute(pl, base + ['stash', 'list', '--no-decorate'])[0])
 
         if show_tag:
-            tag, err = self.execute(pl, base + ['describe', '--tags', '--abbrev=0'])
+            tag, err = self.execute(pl, base + ['describe', '--tags', '--abbrev=0'] + (['--exact-match'] if tag_exact_match else []))
 
             if err and ('error' in err[0] or 'fatal' in err[0]):
                 tag = ''
@@ -168,6 +168,10 @@ if that number is greater than zero.
 :param bool show_tag:
     Show the most recent tag reachable in the current branch.
     False by default, because it needs to execute git an additional time.
+
+:param bool tag_exact_match:
+    Show the tag directly referencing the current commit when ``show_tag`` is set to ``true``.
+    False by default.
 
 Divider highlight group used: ``gitstatus:divider``.
 


### PR DESCRIPTION
When `show_tag` is set to true, I found showing the *most recent* tag can be confusing. This PR adds an option `tag_exact_match` to show the tag only when it directly references the current commit.