### PR TITLE
📝 Update format config example on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,14 +132,14 @@ theme configuration file, for example `.config/powerline/themes/shell/__main__.j
     "args": { 
         "formats": {
             "branch": "\ue0a0 {}",
-            "tag": " {}",
-            "behind": " {}",
-            "ahead": " {}",
-            "staged": " {}",
-            "unmerged": " {}",
-            "changed": " {}",
-            "untracked": " {}",
-            "stashed": " {}"
+            "tag": " ★ {}",
+            "behind": " ↓ {}",
+            "ahead": " ↑ {}",
+            "staged": " ● {}",
+            "unmerged": " ✖ {}",
+            "changed": " ✚ {}",
+            "untracked": " … {}",
+            "stashed": " ⚑ {}"
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Note: before v1.3.0, the behavior when the value is `True` was `last`. As of v1.
 
 Optionally the format in which Gitstatus shows information can be customized.
 This allows to use a different symbol or remove a fragment if desired. You can
-customize string formats for _tag_, _behind_, _ahead_, _staged_, _unmerged_,
+customize string formats for _branch_, _tag_, _behind_, _ahead_, _staged_, _unmerged_,
 _changed_, _untracked_ and _stash_ fragments with the following arguments in a
 theme configuration file, for example `.config/powerline/themes/shell/__main__.json`:
 
@@ -131,6 +131,7 @@ theme configuration file, for example `.config/powerline/themes/shell/__main__.j
 "gitstatus": {
     "args": { 
         "formats": {
+            "branch": "\ue0a0 {}",
             "tag": " {}",
             "behind": " {}",
             "ahead": " {}",


### PR DESCRIPTION
The new `formats` configuration in 1.3.1 is awesome! However, I found the example configuration confusing because it uses formats which _delete_ the default symbols. It took me a while to figure out the spacing around each symbol - all I wanted to do was adjust the spaces but use the same symbols.

Ended up digging into the code to figure out the characters used, but also noticed that `branch` has a configurable format!

This PR updates the `formats` example on the readme:

1. Adds `branch` default format
1. Updates other formats with default string format

IMHO,  this is a better starting point for users to play with these formats. It would have saved me at least a half hour.