### PR TITLE
Fix the IndexError exception raised by popping an empty list of git status

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,17 @@ shell theme.
 pip install powerline-gitstatus
 ```
 
+### Manual installation
+1. Put powerline_gitstatus folder to ```$powerline_root/powerline/segments```
+2. Add the following segment to your powerline config file, e.g. `.config/powerline/themes/shell/default.json`
+```json
+{
+    "function": "powerline.segments.powerline_gitstatus.segments.gitstatus",
+    "priority": 40
+}
+```
+
+
 Configuration
 -------------
 

--- a/powerline_gitstatus/segments.py
+++ b/powerline_gitstatus/segments.py
@@ -126,7 +126,8 @@ class GitStatusSegment(Segment):
 
         status, err = self.execute(pl, base + ['status', '--branch', '--porcelain'])
 
-        if err and ('error' in err[0] or 'fatal' in err[0]):
+        # taoyl: status might be empty, popping it causes an Exception
+        if not status or err and ('error' in err[0] or 'fatal' in err[0]):
             return
 
         branch, detached, behind, ahead = self.parse_branch(status.pop(0))


### PR DESCRIPTION
When returned git status is an empty list, popping it will raise an IndexError exception as follows.
So add sanity checking to status before parsing branch status.

```
2019-12-19 10:38:19,910:ERROR:shell:gitstatus:Exception while computing segment: pop from empty list
Traceback (most recent call last):
  File "/home/taoyl/powerline/powerline/segment.py", line 173, in process_segment
    contents = segment['contents_func'](pl, segment_info)
  File "/home/taoyl/powerline/powerline/segment.py", line 412, in <lambda>
    contents_func = lambda pl, segment_info: _contents_func(pl=pl, segment_info=segment_info, **args)
  File "/home/taoyl/powerline/powerline/segments/powerline_gitstatus/segments.py", line 132, in __call__
    branch, detached, behind, ahead = self.parse_branch(status.pop(0))
IndexError: pop from empty list
```