### PR TITLE
Fix for show_tag=last

### DIFF
--- a/powerline_gitstatus/segments.py
+++ b/powerline_gitstatus/segments.py
@@ -149,7 +149,10 @@ class GitStatusSegment(Segment):
         elif show_tag == 'contains':
             tag, err = self.execute(pl, base + ['describe', '--contains'])
         elif show_tag == 'last':
-            tag, err = self.execute(pl, base + ['describe', '--tags'])
+           tag = ''
+           hash, err = self.execute(pl, base + ['rev-list', '--tags', '--max-count=1'])
+           if not err and hash:
+               tag, err = self.execute(pl, base + ['describe', '--tags', hash[0]])
         elif show_tag == 'annotated':
             tag, err = self.execute(pl, base + ['describe'])
         else:

--- a/powerline_gitstatus/segments.py
+++ b/powerline_gitstatus/segments.py
@@ -11,7 +11,7 @@ class GitStatusSegment(Segment):
 
     def execute(self, pl, command):
         pl.debug('Executing command: %s' % ' '.join(command))
-	
+
         git_env = os.environ.copy()
         git_env['LC_ALL'] = 'C' 
 
@@ -160,6 +160,8 @@ class GitStatusSegment(Segment):
 
         if err and ('error' in err[0] or 'fatal' in err[0] or 'Could not get sha1 for HEAD' in err[0]):
             tag = ''
+        elif tag == '':
+            tag = tag
         else:
             tag = tag[0]
 


### PR DESCRIPTION
 Using `git describe --tags` doesn't ultimately give the latest tag that was created. Therefore `git rev-list --tags --max-count=1` was used to grab the hash of the latest tag and then supply the hash to `git describe --tags HASH_VALUE`

A quick dry-run on shell:
1. Get to the root of any directory initialized with git.
2. `git describe --tags $(git rev-list --tags --max-count=1)`